### PR TITLE
Add alps2dot build for asd --validate support

### DIFF
--- a/asd.rb
+++ b/asd.rb
@@ -21,6 +21,12 @@ class Asd < Formula
       # npm install の実行
       system "npm", "install", "--prefix", "#{libexec}/asd-sync"
 
+      # alps2dot のビルド
+      system "npm", "install", "--prefix", "#{libexec}/alps2dot"
+      Dir.chdir("#{libexec}/alps2dot") do
+        system "npm", "run", "build"
+      end
+
       # 必要なファイルに実行権限を付与し、shebangを追加
       bin_asd = "#{libexec}/bin/asd"
       chmod 0755, bin_asd


### PR DESCRIPTION
## Summary
- Add alps2dot npm install and build step to formula
- Enables `asd --validate` command for ALPS profile validation

## Note
This PR should be merged after 0.16 release, which includes alps2dot source in PHAR.

## Related
- alps-asd/app-state-diagram PR #224