### PR TITLE
Use explicit php@8.4 path instead of relying on PATH

### DIFF
--- a/asd.rb
+++ b/asd.rb
@@ -12,11 +12,14 @@ class Asd < Formula
 
 
   def install
+      # Get the PHP binary path from the dependency
+      php_bin = Formula["php@8.4"].opt_bin/"php"
+
       # PHARファイルをlibexecにインストール
       libexec.install "asd.phar"
 
       # PHARファイルを解凍
-      system "php -r \"(new Phar('#{libexec}/asd.phar'))->extractTo('#{libexec}');\""
+      system php_bin, "-r", "(new Phar('#{libexec}/asd.phar'))->extractTo('#{libexec}');"
 
       # npm install の実行
       system "npm", "install", "--prefix", "#{libexec}/asd-sync"
@@ -43,10 +46,10 @@ class Asd < Formula
       EOS
       (bin/"asdw").chmod 0755
 
-      # asd.phar 実行スクリプトの作成
+      # asd.phar 実行スクリプトの作成 (use php@8.4 explicitly)
       (bin/"asd").write <<~EOS
         #!/bin/bash
-        php "#{libexec}/asd.phar" "$@"
+        "#{Formula["php@8.4"].opt_bin}/php" "#{libexec}/asd.phar" "$@"
       EOS
       (bin/"asd").chmod 0755
     end


### PR DESCRIPTION
## Problem
Installation fails with `sh: php: command not found` when users have PHP installed via shivammathur/php tap instead of Homebrew's default php.

The formula was using `system "php -r ..."` which relies on `php` being in PATH, but Homebrew's `php@8.4` dependency doesn't automatically add itself to PATH.

## Solution
- Use `Formula["php@8.4"].opt_bin/"php"` to get the explicit path to the PHP binary
- Apply this fix to both:
  - PHAR extraction during install
  - Runtime `asd` wrapper script

## Changes
- Line 16: Store PHP binary path in variable
- Line 22: Use `php_bin` variable for PHAR extraction
- Lines 50-53: Use explicit PHP path in wrapper script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated to explicitly use PHP 8.4 binary for improved compatibility and reliability across different system environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->