### PR TITLE
Use shivammathur/php tap to avoid conflict

### DIFF
--- a/asd.rb
+++ b/asd.rb
@@ -5,15 +5,14 @@ class Asd < Formula
   sha256 "ed443bc76e410e92a5b1b819e41f7a944f430c203786ba33628e66ad70ad7c1f"
   license "MIT"
 
-  depends_on "php@8.4"
-  depends_on "composer" => :build
+  depends_on "shivammathur/php/php@8.4"
   depends_on "node"
   depends_on "graphviz"
 
 
   def install
       # Get the PHP binary path from the dependency
-      php_bin = Formula["php@8.4"].opt_bin/"php"
+      php_bin = Formula["shivammathur/php/php@8.4"].opt_bin/"php"
 
       # PHARファイルをlibexecにインストール
       libexec.install "asd.phar"
@@ -46,10 +45,10 @@ class Asd < Formula
       EOS
       (bin/"asdw").chmod 0755
 
-      # asd.phar 実行スクリプトの作成 (use php@8.4 explicitly)
+      # asd.phar 実行スクリプトの作成 (use shivammathur php@8.4 explicitly)
       (bin/"asd").write <<~EOS
         #!/bin/bash
-        "#{Formula["php@8.4"].opt_bin}/php" "#{libexec}/asd.phar" "$@"
+        "#{Formula["shivammathur/php/php@8.4"].opt_bin}/php" "#{libexec}/asd.phar" "$@"
       EOS
       (bin/"asd").chmod 0755
     end


### PR DESCRIPTION
## Problem
Installation fails with `Error: php is already installed from shivammathur/php!` for users who have PHP installed from the shivammathur tap.

## Solution
Change PHP dependency from Homebrew's `php@8.4` to `shivammathur/php/php@8.4` explicitly.

This ensures compatibility with the popular shivammathur/php tap that many PHP developers use.

## Tested
- Local installation successful
- `asd --version` → `asd version 0.16.0 (Homebrew)`
- `asd --validate` works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP 8.4 dependency to use an alternative vendor source for improved compatibility and long-term maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->